### PR TITLE
A-1202501697330831: receive BTC unit fix

### DIFF
--- a/screen/receive/details.js
+++ b/screen/receive/details.js
@@ -26,8 +26,9 @@ const ReceiveDetails = () => {
   const wallet = wallets.find((w) => w.getID() === walletID);
   const [customLabel, setCustomLabel] = useState();
   const [customAmount, setCustomAmount] = useState();
-  const [customAmountPreview, setCustomAmountPreview] = useState();
+  const [customAmountPreview, setCustomAmountPreview] = useState(0);
   const [customUnit, setCustomUnit] = useState(BitcoinUnit.BTC);
+  const [customUnitPreview, setCustomUnitPreview] = useState(BitcoinUnit.BTC);
   const [bip21encoded, setBip21encoded] = useState();
   const [isCustom, setIsCustom] = useState(false);
   const [isCustomModalVisible, setIsCustomModalVisible] = useState(false);
@@ -405,29 +406,48 @@ const ReceiveDetails = () => {
 
   const showCustomAmountModal = () => {
     setIsCustomModalVisible(true);
+    setCustomUnitPreview(customUnit);
+    let displayAmount = customAmount;
+    switch (customUnit) {
+      case BitcoinUnit.BTC:
+        displayAmount = customAmount;
+        break;
+      case BitcoinUnit.SATS:
+        displayAmount = currency.btcToSatoshi(customAmount);
+        break;
+      case BitcoinUnit.LOCAL_CURRENCY:
+        displayAmount = currency.BTCToLocalCurrency(customAmount);
+        displayAmount = parseFloat(displayAmount.replace(/[^0-9.-]+/g, ''));
+        break;
+    }
+
+    setCustomAmountPreview(displayAmount);
   };
 
   const createCustomAmountAddress = () => {
     setIsCustom(true);
     setIsCustomModalVisible(false);
     let amount = customAmountPreview;
-    switch (customUnit) {
+    switch (customUnitPreview) {
       case BitcoinUnit.BTC:
         // nop
         break;
       case BitcoinUnit.SATS:
-        amount = currency.satoshiToBTC(customAmount);
+        amount = currency.satoshiToBTC(customAmountPreview);
         break;
       case BitcoinUnit.LOCAL_CURRENCY:
         if (AmountInput.conversionCache[amount + BitcoinUnit.LOCAL_CURRENCY]) {
           // cache hit! we reuse old value that supposedly doesnt have rounding errors
           amount = currency.satoshiToBTC(AmountInput.conversionCache[amount + BitcoinUnit.LOCAL_CURRENCY]);
         } else {
-          amount = currency.fiatToBTC(customAmount);
+          amount = currency.fiatToBTC(customAmountPreview);
         }
         break;
     }
     setCustomAmount(amount);
+    setCustomUnit(customUnitPreview);
+    setCustomUnitPreview(null);
+    setCustomAmountPreview(null);
     setBip21encoded(DeeplinkSchemaMatch.bip21encode(address, { amount, label: customLabel }));
     setShowAddress(true);
   };
@@ -437,7 +457,7 @@ const ReceiveDetails = () => {
       <BottomModal isVisible={isCustomModalVisible} onClose={dismissCustomAmountModal}>
         <KeyboardAvoidingView enabled={!Platform.isPad} behavior={Platform.OS === 'ios' ? 'position' : null}>
           <View style={stylesHook.modalContent}>
-            <AmountInput unit={customUnit} amount={customAmountPreview || customAmount || ''} onChangeText={setCustomAmountPreview} onAmountUnitChange={setCustomUnit} />
+            <AmountInput unit={customUnitPreview} amount={customAmountPreview} onChangeText={setCustomAmountPreview} onAmountUnitChange={setCustomUnitPreview} />
             <View style={stylesHook.customAmount}>
               <TextInput onChangeText={setCustomLabel} placeholderTextColor="#81868e" placeholder={loc.receive.details_label} value={customLabel || ''} numberOfLines={1} style={stylesHook.customAmountText} testID="CustomAmountDescription" />
             </View>
@@ -462,15 +482,7 @@ const ReceiveDetails = () => {
    */
   const getDisplayAmount = () => {
     if (Number(customAmount) > 0) {
-      switch (customUnit) {
-        case BitcoinUnit.BTC:
-          return customAmount + ' BTC';
-        case BitcoinUnit.SATS:
-          return currency.satoshiToBTC(customAmount) + ' BTC';
-        case BitcoinUnit.LOCAL_CURRENCY:
-          return currency.fiatToBTC(customAmount) + ' BTC';
-      }
-      return customAmount + ' ' + customUnit;
+      return customAmount + ' BTC';
     } else {
       return null;
     }


### PR DESCRIPTION
Logic behind this implementation is keeping amount uniform in BTC, just like it was originally, but considering separate state for modal, also changed place for currency conversion, to keep amount in BTC on receive details screen.

test1

https://user-images.githubusercontent.com/1914249/177932041-16f86e7f-d112-48f2-9f50-3e525d5e8f17.mp4

test2 - case described in the ticket

https://user-images.githubusercontent.com/1914249/177932012-eefecefe-9194-47d8-8e78-a787c0d671f7.mp4

Note that on QR code screen amounts always was in BTC, units are only for editing. as an enhancement option we can add USD(or other local currency) right below BTC
