### PR TITLE
A-1202566945821822: dont allow empty passphrase if passphrase checkbox was enabled

### DIFF
--- a/blue_modules/prompt.js
+++ b/blue_modules/prompt.js
@@ -2,7 +2,7 @@ import { Platform } from 'react-native';
 import prompt from 'react-native-prompt-android';
 import loc from '../loc';
 
-module.exports = (title, text, isCancelable = true, type = 'secure-text', isOKDestructive = false, continueButtonText = loc._.ok) => {
+module.exports = (title, text, isCancelable = true, type = 'secure-text', isOKDestructive = false, continueButtonText = loc._.ok, allowEmpty = true) => {
   const keyboardType = type === 'numeric' ? 'numeric' : 'default';
 
   if (Platform.OS === 'ios' && type === 'numeric') {
@@ -24,7 +24,11 @@ module.exports = (title, text, isCancelable = true, type = 'secure-text', isOKDe
             text: continueButtonText,
             onPress: (password) => {
               console.log('OK Pressed');
-              resolve(password);
+              if (password === '' && !allowEmpty) {
+                reject(Error('Empty ' + title));
+              } else {
+                resolve(password);
+              }
             },
             style: isOKDestructive ? 'destructive' : 'default',
           },
@@ -34,7 +38,11 @@ module.exports = (title, text, isCancelable = true, type = 'secure-text', isOKDe
             text: continueButtonText,
             onPress: (password) => {
               console.log('OK Pressed');
-              resolve(password);
+              if (password === '' && !allowEmpty) {
+                reject(Error('Empty field'));
+              } else {
+                resolve(password);
+              }
             },
           },
         ];

--- a/loc/en.json
+++ b/loc/en.json
@@ -488,6 +488,7 @@
     "export_title": "Wallet Export",
     "import_do_import": "Import",
     "import_passphrase": "Passphrase",
+    "import_passphrase_description": "Enable this option only if you have used passphrase for your wallet",
     "import_passphrase_title": "Passphrase",
     "import_passphrase_message": "Enter passphrase if you have used any",
     "import_error": "Failed to import. Please make sure that the provided data is valid.",

--- a/screen/wallets/import.js
+++ b/screen/wallets/import.js
@@ -145,6 +145,9 @@ const WalletsImport = () => {
             <Switch testID="AskPassphrase" value={askPassphrase} onValueChange={setAskPassphrase} />
           </View>
           <View style={styles.row}>
+            <BlueText>{loc.wallets.import_passphrase_description}</BlueText>
+          </View>
+          <View style={styles.row}>
             <BlueText>{loc.wallets.import_search_accounts}</BlueText>
             <Switch testID="SearchAccounts" value={searchAccounts} onValueChange={setSearchAccounts} />
           </View>

--- a/screen/wallets/importDiscovery.js
+++ b/screen/wallets/importDiscovery.js
@@ -25,7 +25,7 @@ const ImportWalletDiscovery = () => {
   const [password, setPassword] = useState();
   const [selected, setSelected] = useState(0);
   const [progress, setProgress] = useState();
-  const [isTestMode, setIsTestMode] = useState(false);
+  const [isTestMode, setIsTestMode] = useState(null);
   const importing = useRef(false);
   const bip39 = useMemo(() => {
     const hd = new HDSegwitBech32Wallet({ network: isTestMode ? bitcoin.networks.testnet : bitcoin.networks.bitcoin });
@@ -54,6 +54,11 @@ const ImportWalletDiscovery = () => {
   };
 
   useEffect(() => {
+    if (isTestMode === null) {
+      // do nothing
+      return;
+    }
+
     const onProgress = (data) => setProgress(data);
 
     const onWallet = (wallet) => {
@@ -68,11 +73,14 @@ const ImportWalletDiscovery = () => {
 
     const onPassword = async (title, subtitle) => {
       try {
-        const pass = await prompt(title, subtitle);
+        const pass = await prompt(title, subtitle, true, 'secure-text', false, loc._.ok, false);
         setPassword(pass);
         return pass;
       } catch (e) {
         if (e.message === 'Cancel Pressed') {
+          navigation.goBack();
+        }
+        if (e.message.includes('Empty')) {
           navigation.goBack();
         }
         throw e;


### PR DESCRIPTION
This PR includes clarification for Passphrase checkbox according to new logic. 
Bug related to double Prompt window was caused by incorrect useEffect dependencies. Effect was called twice.

| | |
|-|-|
|  ![Simulator Screen Shot - iPhone 12 - 2022-07-20 1](https://user-images.githubusercontent.com/1914249/180086692-41d3ab27-e877-4be8-8a51-0e0420427645.png) | ![Simulator Screen Shot - iPhone 12 - 2022-07-20 2](https://user-images.githubusercontent.com/1914249/180086689-367b04a8-20bd-40a0-bdcc-715f5b6e16fe.png)  |
|-|-|
| ![Simulator Screen Shot - iPhone 12 - 2022-07-20 3](https://user-images.githubusercontent.com/1914249/180086686-4524d051-793d-429a-ac01-93d8fe1616f6.png)  | ![Simulator Screen Shot - iPhone 12 - 2022-07-20 4](https://user-images.githubusercontent.com/1914249/180086681-616a5c96-f7c6-41a0-b969-5631d5632fbd.png)  |
